### PR TITLE
Apply annual climate effects to baseline soil and veg c fluxes in CALAND()

### DIFF
--- a/CALAND.r
+++ b/CALAND.r
@@ -142,8 +142,7 @@ value_col_accum = 7
 ADD_accum = TRUE
 WRITE_OUT_FILE = TRUE
 
-CALAND <- function(scen_file_arg, c_file_arg = "carbon_input.xls", indir = "", outdir = "", start_year = 2010, end_year = 2051, value_col_dens = 7, 
-                   ADD_dens = TRUE, value_col_accum = 7, ADD_accum = TRUE, WRITE_OUT_FILE = TRUE) {
+CALAND <- function(scen_file_arg, c_file_arg = "carbon_input.xls", indir = "", outdir = "", start_year = 2010, end_year = 2051, value_col_dens = 7, ADD_dens = TRUE, value_col_accum = 7, ADD_accum = TRUE, WRITE_OUT_FILE = TRUE) {
   cat("Start CALAND at", date(), "\n")
   
   # output label for: value_col and ADD select which carbon density and accumulation values to use; see notes above


### PR DESCRIPTION
#28  CALAND now reads in 2 new worksheets from the scenario files (i.e. annual climate scalars for veg and soil c fluxes). They are applied to the baseline c fluxes from carbon_input.xls within the annual loop. 

I tested that the update works using a dummy scenario input file with the 2 new worksheets and all scalars equal to 1. The output file was equal to the previous version output.